### PR TITLE
KW-46: Implement Job Creation API

### DIFF
--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -44,6 +44,6 @@ func LoadDB() (*gorm.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	db.AutoMigrate(&model.User{})
+	db.AutoMigrate(&model.User{}, &model.Job{})
 	return db, nil
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.27.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -24,6 +24,8 @@ github.com/go-playground/validator/v10 v10.27.0 h1:w8+XrWVMhGkxOaaowyKH35gFydVHO
 github.com/go-playground/validator/v10 v10.27.0/go.mod h1:I5QpIEbmr8On7W0TktmJAumgzX4CA1XNl4ZmDuVHKKo=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=

--- a/backend/handlers/job.go
+++ b/backend/handlers/job.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"ku-work/backend/model"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type JobHandlers struct {
+	DB *gorm.DB
+}
+
+func NewJobHandlers(db *gorm.DB) *JobHandlers {
+	return &JobHandlers{
+		DB: db,
+	}
+}
+
+func (h *JobHandlers) CreateJob(ctx *gin.Context) {
+	// probUserId, hasUserId := ctx.Get("userid")
+	// if !hasUserId {
+	// 	ctx.String(http.StatusUnauthorized, "Unauthorized")
+	// 	return
+	// }
+	// userid := probUserId.(uint)
+	userid := 1
+	var user model.User
+	userQueryResult := h.DB.First(&user, userid)
+	if userQueryResult.Error != nil {
+		ctx.String(http.StatusInternalServerError, userQueryResult.Error.Error())
+		return
+	}
+	type CreateJobInput struct {
+		Name        string `json:"name" binding:"required,max=128"`
+		Position    string `json:"position" binding:"required,max=128"`
+		Duration    string `json:"duration" binding:"required,max=128"`
+		Description string `json:"description" binding:"required,max=16384"`
+		Location    string `json:"location" binding:"required,max=128"`
+		JobType     string `json:"jobtype" binding:"required,oneof='fulltime' 'parttime' 'contract' 'casual'"`
+		Experience  string `json:"experience" binding:"required,oneof='newgrad' 'junior' 'senior' 'manager'"`
+		MinSalary   uint   `json:"minsalary" binding:"required"`
+		MaxSalary   uint   `json:"maxsalary" binding:"required"`
+	}
+	input := CreateJobInput{}
+	err := ctx.Bind(&input)
+	if err != nil || input.MaxSalary < input.MinSalary {
+		ctx.String(http.StatusBadRequest, err.Error())
+		return
+	}
+	job := model.Job{
+		Name: input.Name,
+		CompanyID: user.ID,
+		Position: input.Position,
+		Duration: input.Duration,
+		Description: input.Description,
+		Location: input.Location,
+		JobType: model.JobType(input.JobType),
+		Experience: model.ExperienceType(input.Experience),
+		MinSalary: input.MinSalary,
+		MaxSalary: input.MaxSalary,
+		IsApproved: false,
+	}
+	result := h.DB.Create(&job)
+	if result.Error != nil {
+		ctx.String(http.StatusInternalServerError, result.Error.Error())
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{
+		"id": job.ID,
+	})
+}

--- a/backend/handlers/routes.go
+++ b/backend/handlers/routes.go
@@ -8,6 +8,7 @@ import (
 func SetupRoutes(router *gin.Engine, db *gorm.DB) {
 	// Initialize handlers
 	userHandlers := NewUserHandlers(db)
+	jobHandlers := NewJobHandlers(db)
 
 	// Health check route
 	router.GET("/", userHandlers.HealthCheck)
@@ -15,4 +16,7 @@ func SetupRoutes(router *gin.Engine, db *gorm.DB) {
 	// User routes
 	router.GET("/users", userHandlers.GetUsers)
 	router.POST("/create_user", userHandlers.CreateUser)
+
+	// Job routes
+	router.POST("/create_job", jobHandlers.CreateJob)
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -25,6 +25,9 @@ func main() {
 	corsConfig := middleware.SetupCORS()
 	router.Use(cors.New(corsConfig))
 
+	// Setup Auth middleware
+	router.Use(middleware.Auth)
+
 	// Setup routes
 	handlers.SetupRoutes(router, db)
 

--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"errors"
+	"os"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+var jwtKey = []byte("")
+
+func InitAuth() error {
+	secretJWTKey, hasJWTKey := os.LookupEnv("JWT_SECRET")
+	if !hasJWTKey {
+		return errors.New("no JWT secret specified")
+	}
+	jwtKey = []byte(secretJWTKey)
+	return nil
+}
+
+type Claims struct {
+    UserId uint `json:"userid"`
+    jwt.RegisteredClaims
+}
+
+func Auth(ctx *gin.Context) {
+	token, err := ctx.Cookie("Token")
+	if err != nil {
+		claims := &Claims{}
+		token, err := jwt.ParseWithClaims(token, claims, func(token *jwt.Token) (any, error) {
+			return jwtKey, nil
+		})
+		if err != nil || !token.Valid {
+            ctx.Next()
+            return
+        }
+		ctx.Set("userid", claims.UserId)
+	}
+	ctx.Next()
+}

--- a/backend/model/job.go
+++ b/backend/model/job.go
@@ -1,0 +1,40 @@
+package model
+
+import (
+	"time"
+)
+
+type ExperienceType string
+
+const (
+	NewGrad ExperienceType = "newgrad"
+	Junior  ExperienceType = "junior"
+	Senior  ExperienceType = "senior"
+	Manager ExperienceType = "manager"
+)
+
+type JobType string
+
+const (
+	FullTime JobType = "fulltime"
+	PartTime JobType = "parttime"
+	Contract JobType = "contract"
+	Casual   JobType = "casual"
+)
+
+type Job struct {
+	ID          uint `gorm:"primaryKey"`
+	CreatedAt   time.Time
+	Name        string
+	CompanyID   uint
+	Company     User `gorm:"foreignKey:CompanyRefer"`
+	Position    string
+	Duration    string
+	Description string
+	Location    string
+	JobType     JobType        `gorm:"type:enum('fulltime', 'parttime', 'contract', 'casual')"`
+	Experience  ExperienceType `gorm:"type:enum('newgrad', 'junior', 'senior', 'manager')"`
+	MinSalary   uint
+	MaxSalary   uint
+	IsApproved  bool
+}


### PR DESCRIPTION
new Job model
endpoint at POST /create_job
also implement simple auth middleware to check is admin, login/signup is not implemented in this PR tho
check handlers/job.go for API