### PR TITLE
fix: change middleware usage to group for better route organization

### DIFF
--- a/backend/handlers/routes.go
+++ b/backend/handlers/routes.go
@@ -20,13 +20,13 @@ func SetupRoutes(router *gin.Engine, db *gorm.DB) {
 	router.POST("/logout", jwtHandler.LogoutHandler)
 
 	// Authentication Protected Routes
-	authed := router.Use(middlewares.AuthMiddleware(jwtHandler.JWTSecret))
+	authed := router.Group("/", middlewares.AuthMiddleware(jwtHandler.JWTSecret))
 	authed.GET("/protected", func(ctx *gin.Context) {
 		ctx.JSON(200, gin.H{"message": "Protected route"})
 	})
 	
 	// Admin Routes
-	admin := authed.Use(middlewares.AdminPermissionMiddleware(db))
+	admin := authed.Group("/", middlewares.AdminPermissionMiddleware(db))
 	admin.GET("/admin", func(ctx *gin.Context) {
 		ctx.JSON(200, gin.H{"message": "Admin route"})
 	})


### PR DESCRIPTION
Due to a problem with multiple middleware changing from `router.Use` to `router.Group`