### PR TITLE
feat!: allow admin fetching, ApprovalStatus, tests improvement

### DIFF
--- a/backend/handlers/google_oauth.go
+++ b/backend/handlers/google_oauth.go
@@ -183,11 +183,7 @@ func (h *OauthHandlers) GoogleOauthHandler(ctx *gin.Context) {
 		if count > 0 {
 			var student model.Student
 			h.DB.Model(&student).Where("user_id = ?", user.ID).First(&student)
-			if student.Approved {
-				isStudent = true
-			} else {
-				isStudent = false
-			}
+			isStudent = student.ApprovalStatus == model.StudentApprovalAccepted
 		}
 	}
 

--- a/backend/handlers/job.go
+++ b/backend/handlers/job.go
@@ -208,9 +208,6 @@ func (h *JobHandlers) FetchJobs(ctx *gin.Context) {
 	if isCompany {
 		var jobsWithStats []JobWithApplicationStatistics
 		result = query.Find(&jobsWithStats)
-		for _, job := range jobsWithStats {
-			println(job.ID)
-		}
 		if result.Error != nil {
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": result.Error.Error()})
 			return

--- a/backend/handlers/jwt.go
+++ b/backend/handlers/jwt.go
@@ -120,7 +120,7 @@ func (h *JWTHandlers) RefreshTokenHandler(ctx *gin.Context) {
 
 		// Check if user is a student
 		var sCount int64
-		h.DB.Model(&model.Student{}).Where("user_id = ? AND approved = ?", user.ID, true).Count(&sCount)
+		h.DB.Model(&model.Student{}).Where("user_id = ? AND approval_status = ?", user.ID, model.StudentApprovalAccepted).Count(&sCount)
 		isStudent = sCount > 0
 	}
 

--- a/backend/model/job.go
+++ b/backend/model/job.go
@@ -26,23 +26,31 @@ const (
 	JobTypeInternship JobType = "internship"
 )
 
+type JobApprovalStatus string
+
+const (
+	JobApprovalAccepted JobApprovalStatus = "accepted"
+	JobApprovalRejected JobApprovalStatus = "rejected"
+	JobApprovalPending  JobApprovalStatus = "pending"
+)
+
 type Job struct {
-	ID              uint             `gorm:"primaryKey" json:"id"`
-	CreatedAt       time.Time        `json:"createdAt"`
-	Name            string           `json:"name"`
-	CompanyID       string           `gorm:"type:uuid" json:"companyId"`
-	Company         Company          `gorm:"foreignKey:CompanyID;constraint:OnDelete:CASCADE;" json:"company"`
-	Position        string           `json:"position"`
-	Duration        string           `json:"duration"`
-	Description     string           `json:"description"`
-	Location        string           `json:"location"`
-	JobType         JobType          `json:"jobType"`
-	Experience      ExperienceType   `json:"experienceType"`
-	MinSalary       uint             `json:"minSalary"`
-	MaxSalary       uint             `json:"maxSalary"`
-	IsApproved      bool             `json:"approved"`
-	IsOpen          bool             `json:"open"`
-	JobApplications []JobApplication `gorm:"foreignkey:JobID;constraint:OnDelete:CASCADE;" json:"-"`
+	ID              uint              `gorm:"primaryKey" json:"id"`
+	CreatedAt       time.Time         `json:"createdAt"`
+	Name            string            `json:"name"`
+	CompanyID       string            `gorm:"type:uuid" json:"companyId"`
+	Company         Company           `gorm:"foreignKey:CompanyID;constraint:OnDelete:CASCADE;" json:"company"`
+	Position        string            `json:"position"`
+	Duration        string            `json:"duration"`
+	Description     string            `json:"description"`
+	Location        string            `json:"location"`
+	JobType         JobType           `json:"jobType"`
+	Experience      ExperienceType    `json:"experienceType"`
+	MinSalary       uint              `json:"minSalary"`
+	MaxSalary       uint              `json:"maxSalary"`
+	ApprovalStatus  JobApprovalStatus `json:"approvalStatus"`
+	IsOpen          bool              `json:"open"`
+	JobApplications []JobApplication  `gorm:"foreignkey:JobID;constraint:OnDelete:CASCADE;" json:"-"`
 }
 
 type JobApplicationStatus string

--- a/backend/model/student.go
+++ b/backend/model/student.go
@@ -7,24 +7,32 @@ import (
 	"gorm.io/gorm"
 )
 
+type StudentApprovalStatus string
+
+const (
+	StudentApprovalAccepted StudentApprovalStatus = "accepted"
+	StudentApprovalRejected StudentApprovalStatus = "rejected"
+	StudentApprovalPending  StudentApprovalStatus = "pending"
+)
+
 type Student struct {
-	UserID              string           `gorm:"type:uuid;primarykey" json:"id"`
-	User                User             `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE;" json:"-"`
-	Approved            bool             `json:"approved"`
-	CreatedAt           time.Time        `json:"createdAt"`
-	Phone               string           `json:"phone"`
-	PhotoID             string           `gorm:"type:uuid" json:"photoId"`
-	Photo               File             `gorm:"foreignKey:PhotoID;constraint:OnDelete:CASCADE;" json:"photo,omitempty"`
-	BirthDate           datatypes.Date   `json:"birthDate"`
-	AboutMe             string           `json:"aboutMe"`
-	GitHub              string           `json:"github"`
-	LinkedIn            string           `json:"linkedIn"`
-	StudentID           string           `json:"studentId"`
-	Major               string           `json:"major"`
-	StudentStatus       string           `json:"status"`
-	StudentStatusFileID string           `gorm:"type:uuid" json:"statusFileId"`
-	StudentStatusFile   File             `gorm:"foreignKey:StudentStatusFileID;constraint:OnDelete:CASCADE;" json:"statusFile,omitempty"`
-	JobApplications     []JobApplication `gorm:"foreignkey:UserID;constraint:OnDelete:CASCADE;" json:"-"`
+	UserID              string                `gorm:"type:uuid;primarykey" json:"id"`
+	User                User                  `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE;" json:"-"`
+	ApprovalStatus      StudentApprovalStatus `json:"approvalStatus"`
+	CreatedAt           time.Time             `json:"createdAt"`
+	Phone               string                `json:"phone"`
+	PhotoID             string                `gorm:"type:uuid" json:"photoId"`
+	Photo               File                  `gorm:"foreignKey:PhotoID;constraint:OnDelete:CASCADE;" json:"photo,omitempty"`
+	BirthDate           datatypes.Date        `json:"birthDate"`
+	AboutMe             string                `json:"aboutMe"`
+	GitHub              string                `json:"github"`
+	LinkedIn            string                `json:"linkedIn"`
+	StudentID           string                `json:"studentId"`
+	Major               string                `json:"major"`
+	StudentStatus       string                `json:"status"`
+	StudentStatusFileID string                `gorm:"type:uuid" json:"statusFileId"`
+	StudentStatusFile   File                  `gorm:"foreignKey:StudentStatusFileID;constraint:OnDelete:CASCADE;" json:"statusFile,omitempty"`
+	JobApplications     []JobApplication      `gorm:"foreignkey:UserID;constraint:OnDelete:CASCADE;" json:"-"`
 }
 
 func (student *Student) BeforeDelete(tx *gorm.DB) (err error) {

--- a/backend/tests/company_test.go
+++ b/backend/tests/company_test.go
@@ -189,15 +189,20 @@ func TestCompany(t *testing.T) {
 	})
 	t.Run("Edit Profile", func(t *testing.T) {
 		username := fmt.Sprintf("companytester-%d", time.Now().UnixNano())
-		var company *model.Company
 		var err error
-		if company, err = CreateAdminCompany(username); err != nil {
+		var userCreationResult *UserCreationResult
+		if userCreationResult, err = CreateUser(UserCreationInfo{
+			Username: username,
+			IsAdmin: true,
+			IsCompany: true,
+		}); err != nil {
 			t.Error(err)
 			return
 		}
 		defer (func() {
-			_ = db.Delete(&company)
+			_ = db.Delete(&userCreationResult.User)
 		})()
+		company := userCreationResult.Company
 		values := map[string]string{
 			"phone":   "0123456789",
 			"address": "1234 gay street bangcock thailand",
@@ -248,15 +253,20 @@ func TestCompany(t *testing.T) {
 
 	t.Run("Get Profile", func(t *testing.T) {
 		username := fmt.Sprintf("companytester-%d", time.Now().UnixNano())
-		var company *model.Company
 		var err error
-		if company, err = CreateAdminCompany(username); err != nil {
+		var userCreationResult *UserCreationResult
+		if userCreationResult, err = CreateUser(UserCreationInfo{
+			Username: username,
+			IsAdmin: true,
+			IsCompany: true,
+		}); err != nil {
 			t.Error(err)
 			return
 		}
 		defer (func() {
-			_ = db.Delete(&company)
+			_ = db.Delete(&userCreationResult.User)
 		})()
+		company := userCreationResult.Company
 		company.Phone = "0123456789"
 		company.Address = "1234 gay street bangcock thailand"
 		if err := db.Save(&company).Error; err != nil {

--- a/backend/tests/company_test.go
+++ b/backend/tests/company_test.go
@@ -192,8 +192,8 @@ func TestCompany(t *testing.T) {
 		var err error
 		var userCreationResult *UserCreationResult
 		if userCreationResult, err = CreateUser(UserCreationInfo{
-			Username: username,
-			IsAdmin: true,
+			Username:  username,
+			IsAdmin:   true,
 			IsCompany: true,
 		}); err != nil {
 			t.Error(err)
@@ -256,8 +256,8 @@ func TestCompany(t *testing.T) {
 		var err error
 		var userCreationResult *UserCreationResult
 		if userCreationResult, err = CreateUser(UserCreationInfo{
-			Username: username,
-			IsAdmin: true,
+			Username:  username,
+			IsAdmin:   true,
 			IsCompany: true,
 		}); err != nil {
 			t.Error(err)

--- a/backend/tests/job_test.go
+++ b/backend/tests/job_test.go
@@ -22,8 +22,8 @@ func TestJob(t *testing.T) {
 		var err error
 		var userCreationResult *UserCreationResult
 		if userCreationResult, err = CreateUser(UserCreationInfo{
-			Username: fmt.Sprintf("createjobtester-%d", time.Now().UnixNano()),
-			IsAdmin: true,
+			Username:  fmt.Sprintf("createjobtester-%d", time.Now().UnixNano()),
+			IsAdmin:   true,
 			IsCompany: true,
 		}); err != nil {
 			t.Error(err)
@@ -89,8 +89,8 @@ func TestJob(t *testing.T) {
 		var err error
 		var userCreationResult *UserCreationResult
 		if userCreationResult, err = CreateUser(UserCreationInfo{
-			Username: fmt.Sprintf("editjobtester-%d", time.Now().UnixNano()),
-			IsAdmin: true,
+			Username:  fmt.Sprintf("editjobtester-%d", time.Now().UnixNano()),
+			IsAdmin:   true,
 			IsCompany: true,
 		}); err != nil {
 			t.Error(err)
@@ -168,8 +168,8 @@ func TestJob(t *testing.T) {
 		var err error
 		var userCreationResult *UserCreationResult
 		if userCreationResult, err = CreateUser(UserCreationInfo{
-			Username: fmt.Sprintf("fetchjobtester-%d", time.Now().UnixNano()),
-			IsAdmin: true,
+			Username:  fmt.Sprintf("fetchjobtester-%d", time.Now().UnixNano()),
+			IsAdmin:   true,
 			IsCompany: true,
 		}); err != nil {
 			t.Error(err)
@@ -180,18 +180,18 @@ func TestJob(t *testing.T) {
 		})()
 		company := userCreationResult.Company
 		job := model.Job{
-			Name:        fmt.Sprintf("nice-job-%d", time.Now().UnixNano()),
-			CompanyID:   company.UserID,
-			Position:    "software engineer",
-			Duration:    "6 months",
-			Description: "make software",
-			Location:    "bangkok",
-			JobType:     model.JobTypeInternship,
-			Experience:  model.ExperienceInternship,
-			MinSalary:   10,
-			MaxSalary:   100,
-			IsOpen:      true,
-			IsApproved:  true,
+			Name:           fmt.Sprintf("nice-job-%d", time.Now().UnixNano()),
+			CompanyID:      company.UserID,
+			Position:       "software engineer",
+			Duration:       "6 months",
+			Description:    "make software",
+			Location:       "bangkok",
+			JobType:        model.JobTypeInternship,
+			Experience:     model.ExperienceInternship,
+			MinSalary:      10,
+			MaxSalary:      100,
+			IsOpen:         true,
+			ApprovalStatus: model.JobApprovalAccepted,
 		}
 		err = db.Create(&job).Error
 		if err != nil {
@@ -210,7 +210,7 @@ func TestJob(t *testing.T) {
 		}
 		student := model.Student{
 			UserID:              company.UserID,
-			Approved:            true,
+			ApprovalStatus:      model.StudentApprovalAccepted,
 			PhotoID:             photoFile.ID,
 			StudentStatusFileID: statusFile.ID,
 		}
@@ -269,8 +269,8 @@ func TestJob(t *testing.T) {
 		var err error
 		var userCreationResult *UserCreationResult
 		if userCreationResult, err = CreateUser(UserCreationInfo{
-			Username: fmt.Sprintf("approvejobtester-%d", time.Now().UnixNano()),
-			IsAdmin: true,
+			Username:  fmt.Sprintf("approvejobtester-%d", time.Now().UnixNano()),
+			IsAdmin:   true,
 			IsCompany: true,
 		}); err != nil {
 			t.Error(err)
@@ -298,7 +298,7 @@ func TestJob(t *testing.T) {
 			return
 		}
 		w := httptest.NewRecorder()
-		payload := fmt.Sprintf(`{"id": %d}`, job.ID)
+		payload := fmt.Sprintf(`{"id": %d,"approve": true}`, job.ID)
 		req, _ := http.NewRequest("POST", "/job/approve", strings.NewReader(payload))
 		jwtHandler := handlers.NewJWTHandlers(db)
 		jwtToken, _, err := jwtHandler.GenerateTokens(company.UserID)
@@ -329,6 +329,7 @@ func TestJob(t *testing.T) {
 			t.Error(err)
 			return
 		}
+		assert.Equal(t, edited_job.ApprovalStatus, model.JobApprovalAccepted)
 		assert.Equal(t, edited_job.Name, job.Name)
 		assert.Equal(t, edited_job.Position, "software engineer")
 		assert.Equal(t, edited_job.Duration, "6 months")
@@ -343,8 +344,8 @@ func TestJob(t *testing.T) {
 		var err error
 		var userCreationResult *UserCreationResult
 		if userCreationResult, err = CreateUser(UserCreationInfo{
-			Username: fmt.Sprintf("applyjobtester-%d", time.Now().UnixNano()),
-			IsAdmin: true,
+			Username:  fmt.Sprintf("applyjobtester-%d", time.Now().UnixNano()),
+			IsAdmin:   true,
 			IsCompany: true,
 		}); err != nil {
 			t.Error(err)
@@ -377,7 +378,7 @@ func TestJob(t *testing.T) {
 		}
 		student := model.Student{
 			UserID:              user.ID,
-			Approved:            true,
+			ApprovalStatus:      model.StudentApprovalAccepted,
 			PhotoID:             photoFile.ID,
 			StudentStatusFileID: statusFile.ID,
 		}
@@ -386,8 +387,8 @@ func TestJob(t *testing.T) {
 			return
 		}
 		job := model.Job{
-			CompanyID:  company.UserID,
-			IsApproved: true,
+			CompanyID:      company.UserID,
+			ApprovalStatus: model.JobApprovalAccepted,
 		}
 		if result := db.Create(&job); result.Error != nil {
 			t.Error(result.Error)

--- a/backend/tests/job_test.go
+++ b/backend/tests/job_test.go
@@ -19,15 +19,20 @@ import (
 
 func TestJob(t *testing.T) {
 	t.Run("Create", func(t *testing.T) {
-		var company *model.Company
 		var err error
-		if company, err = CreateAdminCompany(fmt.Sprintf("createjobtester-%d", time.Now().UnixNano())); err != nil {
+		var userCreationResult *UserCreationResult
+		if userCreationResult, err = CreateUser(UserCreationInfo{
+			Username: fmt.Sprintf("createjobtester-%d", time.Now().UnixNano()),
+			IsAdmin: true,
+			IsCompany: true,
+		}); err != nil {
 			t.Error(err)
 			return
 		}
 		defer (func() {
-			_ = db.Delete(&company)
+			_ = db.Delete(&userCreationResult.User)
 		})()
+		company := userCreationResult.Company
 		w := httptest.NewRecorder()
 		jobName := fmt.Sprintf("testjob1-%d", time.Now().UnixNano())
 		payload := fmt.Sprintf(`{
@@ -81,15 +86,20 @@ func TestJob(t *testing.T) {
 		assert.Equal(t, job.MaxSalary, uint(2))
 	})
 	t.Run("Edit", func(t *testing.T) {
-		var company *model.Company
 		var err error
-		if company, err = CreateAdminCompany(fmt.Sprintf("createjobtester-%d", time.Now().UnixNano())); err != nil {
+		var userCreationResult *UserCreationResult
+		if userCreationResult, err = CreateUser(UserCreationInfo{
+			Username: fmt.Sprintf("editjobtester-%d", time.Now().UnixNano()),
+			IsAdmin: true,
+			IsCompany: true,
+		}); err != nil {
 			t.Error(err)
 			return
 		}
 		defer (func() {
-			_ = db.Delete(&company)
+			_ = db.Delete(&userCreationResult.User)
 		})()
+		company := userCreationResult.Company
 		job := model.Job{
 			Name:        fmt.Sprintf("nice-job-%d", time.Now().UnixNano()),
 			CompanyID:   company.UserID,
@@ -155,15 +165,20 @@ func TestJob(t *testing.T) {
 		assert.Equal(t, edited_job.MaxSalary, uint(100))
 	})
 	t.Run("Fetch", func(t *testing.T) {
-		var company *model.Company
 		var err error
-		if company, err = CreateAdminCompany(fmt.Sprintf("createjobtester-%d", time.Now().UnixNano())); err != nil {
+		var userCreationResult *UserCreationResult
+		if userCreationResult, err = CreateUser(UserCreationInfo{
+			Username: fmt.Sprintf("fetchjobtester-%d", time.Now().UnixNano()),
+			IsAdmin: true,
+			IsCompany: true,
+		}); err != nil {
 			t.Error(err)
 			return
 		}
 		defer (func() {
-			_ = db.Delete(&company)
+			_ = db.Delete(&userCreationResult.User)
 		})()
+		company := userCreationResult.Company
 		job := model.Job{
 			Name:        fmt.Sprintf("nice-job-%d", time.Now().UnixNano()),
 			CompanyID:   company.UserID,
@@ -251,15 +266,20 @@ func TestJob(t *testing.T) {
 		assert.Equal(t, result.Jobs[0].Position, "software engineer")
 	})
 	t.Run("Approve", func(t *testing.T) {
-		var company *model.Company
 		var err error
-		if company, err = CreateAdminCompany(fmt.Sprintf("createjobtester-%d", time.Now().UnixNano())); err != nil {
+		var userCreationResult *UserCreationResult
+		if userCreationResult, err = CreateUser(UserCreationInfo{
+			Username: fmt.Sprintf("approvejobtester-%d", time.Now().UnixNano()),
+			IsAdmin: true,
+			IsCompany: true,
+		}); err != nil {
 			t.Error(err)
 			return
 		}
 		defer (func() {
-			_ = db.Delete(&company)
+			_ = db.Delete(&userCreationResult.User)
 		})()
+		company := userCreationResult.Company
 		job := model.Job{
 			Name:        fmt.Sprintf("nice-job-%d", time.Now().UnixNano()),
 			CompanyID:   company.UserID,
@@ -320,15 +340,20 @@ func TestJob(t *testing.T) {
 		assert.Equal(t, edited_job.MaxSalary, uint(100))
 	})
 	t.Run("Apply", func(t *testing.T) {
-		var company *model.Company
 		var err error
-		if company, err = CreateAdminCompany(fmt.Sprintf("applyjobtestercom-%d", time.Now().UnixNano())); err != nil {
+		var userCreationResult *UserCreationResult
+		if userCreationResult, err = CreateUser(UserCreationInfo{
+			Username: fmt.Sprintf("applyjobtester-%d", time.Now().UnixNano()),
+			IsAdmin: true,
+			IsCompany: true,
+		}); err != nil {
 			t.Error(err)
 			return
 		}
 		defer (func() {
-			_ = db.Delete(&company)
+			_ = db.Delete(&userCreationResult.User)
 		})()
+		company := userCreationResult.Company
 		user := model.User{
 			Username: fmt.Sprintf("applyjobtester-%d", time.Now().UnixNano()),
 		}

--- a/backend/tests/main_test.go
+++ b/backend/tests/main_test.go
@@ -193,7 +193,7 @@ func CreateUser(config UserCreationInfo) (*UserCreationResult, error) {
 		})()
 		student := model.Student{
 			UserID:              result.User.ID,
-			Approved:            true,
+			ApprovalStatus:      model.StudentApprovalAccepted,
 			PhotoID:             photoFile.ID,
 			StudentStatusFileID: statusFile.ID,
 		}

--- a/backend/tests/student_test.go
+++ b/backend/tests/student_test.go
@@ -10,6 +10,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -125,5 +126,120 @@ func TestStudent(t *testing.T) {
 		assert.Equal(t, student.Major, "Software and Knowledge Engineering")
 		assert.Equal(t, student.StudentStatus, "Graduated")
 		_ = db.Delete(&user)
+	})
+	t.Run("GetCurrentProfile", func(t *testing.T) {
+		student, err := CreateUser(UserCreationInfo{
+			Username:  fmt.Sprintf("getcurrentprofilestudenttester-%d", time.Now().UnixNano()),
+			IsStudent: true,
+			IsOAuth:   true,
+		})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer (func() {
+			_ = db.Delete(&student.User)
+		})()
+		student.OAuth.FirstName = "MyFirstName"
+		student.OAuth.LastName = "MyLastName"
+		student.OAuth.Email = "testemail@email.test"
+		if err := db.Save(&student.OAuth).Error; err != nil {
+			t.Error(err)
+			return
+		}
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/students", strings.NewReader(""))
+		jwtHandler := handlers.NewJWTHandlers(db)
+		jwtToken, _, err := jwtHandler.GenerateTokens(student.User.ID)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwtToken))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		router.ServeHTTP(w, req)
+		assert.Equal(t, w.Code, 200)
+		type StudentInfo struct {
+			model.Student
+			FirstName string `json:"firstName"`
+			LastName  string `json:"lastName"`
+			Email     string `json:"email"`
+		}
+		type Result struct {
+			Profile StudentInfo `json:"profile"`
+			Error   string      `json:"error"`
+		}
+		result := Result{}
+		err = json.Unmarshal(w.Body.Bytes(), &result)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if result.Error != "" {
+			t.Error(result.Error)
+			return
+		}
+		assert.Equal(t, result.Profile.UserID, student.Student.UserID)
+		assert.Equal(t, result.Profile.FirstName, student.OAuth.FirstName)
+		assert.Equal(t, result.Profile.LastName, student.OAuth.LastName)
+		assert.Equal(t, result.Profile.Email, student.OAuth.Email)
+	})
+	t.Run("AdminGetProfiles", func(t *testing.T) {
+		var students []model.Student
+		for i := 0; i < 5; i += 1 {
+			student, err := CreateUser(UserCreationInfo{
+				Username:  fmt.Sprintf("admingetprofilesstudenttester-%d-%d", i, time.Now().UnixNano()),
+				IsStudent: true,
+			})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			defer (func() {
+				_ = db.Delete(&student.User)
+			})()
+			students = append(students, *student.Student)
+		}
+		admin, err := CreateUser(UserCreationInfo{
+			Username: fmt.Sprintf("admingetprofilesstudenttester-%d", time.Now().UnixNano()),
+			IsAdmin:  true,
+		})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer (func() {
+			_ = db.Delete(&admin.User)
+		})()
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/students", strings.NewReader(""))
+		jwtHandler := handlers.NewJWTHandlers(db)
+		jwtToken, _, err := jwtHandler.GenerateTokens(admin.User.ID)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwtToken))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		router.ServeHTTP(w, req)
+		assert.Equal(t, w.Code, 200)
+		var result []model.Student
+		err = json.Unmarshal(w.Body.Bytes(), &result)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		for i, createdStudent := range students {
+			found := false
+			for _, student := range result {
+				if student.UserID == createdStudent.UserID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Student %d not found", i)
+			}
+		}
 	})
 }

--- a/frontend/app/components/job/PostForm.vue
+++ b/frontend/app/components/job/PostForm.vue
@@ -148,7 +148,7 @@
                 <div class="col-span-12 md:col-span-8">
                     <UTextarea
                         v-model="form.description"
-                        rows="6"
+                        :rows="6"
                         placeholder="Enter job description"
                         class="w-full"
                     />
@@ -201,8 +201,8 @@ const form = ref({
     location: "",
     jobtype: "",
     experience: "",
-    minsalary: "",
-    maxsalary: "",
+    minsalary: 0,
+    maxsalary: 0,
     description: "",
     duration: "",
 });
@@ -357,22 +357,8 @@ async function onSubmit() {
         return;
     }
 
-    // Map frontend field names to backend expected names
-    const backendData = {
-        name: result.data.title, // title -> name
-        position: result.data.title, // use title as position too
-        location: result.data.location,
-        jobtype: result.data.type, // type -> jobtype
-        experience: result.data.experience,
-        minsalary: result.data.minSalary, // minSalary -> minsalary
-        maxsalary: result.data.maxSalary, // maxSalary -> maxsalary
-        description: result.data.description,
-        duration: result.data.duration,
-        open: true, // default to open
-    };
-
     try {
-        const response = await api.post("/job", backendData, {
+        const response = await api.post("/job", result.data, {
             withCredentials: true,
         });
 


### PR DESCRIPTION
### Description

- Allow admins to fetch non approved jobs
- Allow admins to fetch non approved users
- Changed `IsApproved` to `ApprovalStatus` or in JSON `approve` to `approvalStatus`
- ApprovalStatus has 3 states, `pending`, `rejected` and `accepted` so students and companies know whether an admin has already review their registration/job
- Removed CreateAdminUser in tests, added CreateUser as replacement that can create admin, student, and company user for testing making it cleaner.
- Added more tests

### Checklist

- [x] I have performed a self-review of my code.
- [ ] I have updated the documentation, if applicable.
- [x] My code follows the Coding Guidelines.

## Remarks

- May break front-end code that uses `approve`, front-end devs please verify that everything works fine, if not, please commit a fix in this branch