### PR TITLE
feat: update configuration to prevent collision of username

### DIFF
--- a/backend/handlers/google_oauth.go
+++ b/backend/handlers/google_oauth.go
@@ -145,6 +145,7 @@ func (h *OauthHandlers) GoogleOauthHandler(ctx *gin.Context) {
 		var newUser model.User
 		h.DB.FirstOrCreate(&newUser, model.User{
 			Username: userInfo.Email,
+			UserType: "oauth",
 		})
 
 		oauthDetail = model.GoogleOAuthDetails{

--- a/backend/handlers/local_auth.go
+++ b/backend/handlers/local_auth.go
@@ -74,7 +74,7 @@ func (h *LocalAuthHandlers) CompanyRegisterHandler(ctx *gin.Context) {
 
 	// Check if a user with the same username already exists.
 	var count int64 = 0
-	h.DB.Model(&model.User{}).Where("username = ?", req.Username).Count(&count)
+	h.DB.Model(&model.User{}).Where("username = ? AND user_type = ?", req.Username, "company").Count(&count)
 
 	if count > 0 {
 		ctx.JSON(http.StatusConflict, gin.H{"error": "Username already exists"})
@@ -96,6 +96,7 @@ func (h *LocalAuthHandlers) CompanyRegisterHandler(ctx *gin.Context) {
 	// Create the new user.
 	newUser := model.User{
 		Username:     req.Username,
+		UserType:     "company",
 		PasswordHash: string(hashedPassword),
 	}
 
@@ -191,7 +192,7 @@ func (h *LocalAuthHandlers) CompanyLoginHandler(ctx *gin.Context) {
 	}
 
 	var user model.User
-	if err := h.DB.Model(&model.User{}).Where("username = ?", req.Username).First(&user).Error; err != nil {
+	if err := h.DB.Model(&model.User{}).Where("username = ? AND user_type = ?", req.Username, "company").First(&user).Error; err != nil {
 		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid credentials"})
 		return
 	}
@@ -245,7 +246,7 @@ func (h *LocalAuthHandlers) AdminLoginHandler(ctx *gin.Context) {
 	}
 
 	var user model.User
-	if err := h.DB.Model(&model.User{}).Where("username = ?", req.Username).First(&user).Error; err != nil {
+	if err := h.DB.Model(&model.User{}).Where("username = ? AND user_type = ?", req.Username, "admin").First(&user).Error; err != nil {
 		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid credentials"})
 		return
 	}

--- a/backend/model/user.go
+++ b/backend/model/user.go
@@ -13,7 +13,8 @@ type User struct {
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 	DeletedAt    gorm.DeletedAt `gorm:"index"`
-	Username     string         `gorm:"unique"`
+	Username     string         `gorm:"index:idx_username_user_type,unique"`
+	UserType     string         `gorm:"index:idx_username_user_type,unique"`
 	PasswordHash string         `json:"-"`
 }
 

--- a/backend/scripts/create_admin.go
+++ b/backend/scripts/create_admin.go
@@ -39,7 +39,7 @@ func main() {
 
 	// Check if user already exists
 	var count int64
-	err = db.Model(&model.User{}).Where("username = ?", username).Count(&count).Error
+	err = db.Model(&model.User{}).Where("username = ? AND user_type = ?", username, "admin").Count(&count).Error
 	if count > 0 {
 		log.Fatalf("User with username '%s' already exists.", username)
 	} else if err != nil {
@@ -54,6 +54,7 @@ func main() {
 	err = db.Transaction(func(tx *gorm.DB) error {
 		user := model.User{
 			Username:     username,
+			UserType:     "admin",
 			PasswordHash: string(hashedPassword),
 		}
 

--- a/backend/tests/company_test.go
+++ b/backend/tests/company_test.go
@@ -98,7 +98,7 @@ func TestCompany(t *testing.T) {
 
 		// Verify user and company in DB
 		var user model.User
-		if err := db.Where("username = ?", username).First(&user).Error; err != nil {
+		if err := db.Where("username = ? AND user_type = ?", username, "company").First(&user).Error; err != nil {
 			t.Fatal(err)
 		}
 
@@ -117,7 +117,7 @@ func TestCompany(t *testing.T) {
 	t.Run("Duplicate Company Creation", func(t *testing.T) {
 		username := fmt.Sprintf("companytester-%d", time.Now().UnixNano())
 		// Create a user first
-		user := model.User{Username: username}
+		user := model.User{Username: username, UserType: "company"}
 		if err := db.Create(&user).Error; err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
### Description

- Add and update model to include `user_type` (admin, company, and oauth)
- Ensure that company with the same name as oauth or admin is allowed and not break system entirely

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have updated the documentation, if applicable.
- [x] My code follows the Coding Guidelines.

## Remarks

- This change should not break any API endpoint.