### PR TITLE
KW-175: add fetch email logs API

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -69,6 +69,56 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/emaillog": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves a list logs related to email i.e, sending success failure, to whom.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Get log of email (Admin only)",
+                "responses": {
+                    "200": {
+                        "description": "List of all audit log entries",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.MailLog"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/applications": {
             "get": {
                 "security": [
@@ -590,7 +640,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Invalidates the user's session by deleting their refresh token from the database and clearing the refresh token cookie.",
+                "description": "Invalidates the user's session by revoking both the JWT token (blacklist) and refresh token. Complies with OWASP session termination requirements.",
                 "produces": [
                     "application/json"
                 ],
@@ -2593,6 +2643,9 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
+                "notifyOnApplication": {
+                    "type": "boolean"
+                },
                 "open": {
                     "type": "boolean"
                 },
@@ -2654,6 +2707,9 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                },
+                "notifyOnApplication": {
+                    "type": "boolean"
                 },
                 "open": {
                     "type": "boolean"
@@ -2843,6 +2899,55 @@ const docTemplate = `{
                 "JobApplicationAccepted",
                 "JobApplicationRejected",
                 "JobApplicationPending"
+            ]
+        },
+        "model.MailLog": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "errorCode": {
+                    "type": "string"
+                },
+                "errorDesc": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "retryCount": {
+                    "description": "Number of retry attempts made",
+                    "type": "integer"
+                },
+                "status": {
+                    "$ref": "#/definitions/model.MailLogStatus"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "to": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.MailLogStatus": {
+            "type": "string",
+            "enum": [
+                "delivered",
+                "temporary_error",
+                "permanent_error"
+            ],
+            "x-enum-varnames": [
+                "MailLogStatusDelivered",
+                "MailLogStatusTemporaryError",
+                "MailLogStatusPermanentError"
             ]
         }
     },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -61,6 +61,56 @@
                 }
             }
         },
+        "/admin/emaillog": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves a list logs related to email i.e, sending success failure, to whom.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Get log of email (Admin only)",
+                "responses": {
+                    "200": {
+                        "description": "List of all audit log entries",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.MailLog"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/applications": {
             "get": {
                 "security": [
@@ -582,7 +632,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Invalidates the user's session by deleting their refresh token from the database and clearing the refresh token cookie.",
+                "description": "Invalidates the user's session by revoking both the JWT token (blacklist) and refresh token. Complies with OWASP session termination requirements.",
                 "produces": [
                     "application/json"
                 ],
@@ -2585,6 +2635,9 @@
                 "name": {
                     "type": "string"
                 },
+                "notifyOnApplication": {
+                    "type": "boolean"
+                },
                 "open": {
                     "type": "boolean"
                 },
@@ -2646,6 +2699,9 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "notifyOnApplication": {
+                    "type": "boolean"
                 },
                 "open": {
                     "type": "boolean"
@@ -2835,6 +2891,55 @@
                 "JobApplicationAccepted",
                 "JobApplicationRejected",
                 "JobApplicationPending"
+            ]
+        },
+        "model.MailLog": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "errorCode": {
+                    "type": "string"
+                },
+                "errorDesc": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "retryCount": {
+                    "description": "Number of retry attempts made",
+                    "type": "integer"
+                },
+                "status": {
+                    "$ref": "#/definitions/model.MailLogStatus"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "to": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.MailLogStatus": {
+            "type": "string",
+            "enum": [
+                "delivered",
+                "temporary_error",
+                "permanent_error"
+            ],
+            "x-enum-varnames": [
+                "MailLogStatusDelivered",
+                "MailLogStatusTemporaryError",
+                "MailLogStatusPermanentError"
             ]
         }
     },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -243,6 +243,8 @@ definitions:
         type: integer
       name:
         type: string
+      notifyOnApplication:
+        type: boolean
       open:
         type: boolean
       photoId:
@@ -284,6 +286,8 @@ definitions:
         type: integer
       name:
         type: string
+      notifyOnApplication:
+        type: boolean
       open:
         type: boolean
       pending:
@@ -415,6 +419,40 @@ definitions:
     - JobApplicationAccepted
     - JobApplicationRejected
     - JobApplicationPending
+  model.MailLog:
+    properties:
+      body:
+        type: string
+      createdAt:
+        type: string
+      errorCode:
+        type: string
+      errorDesc:
+        type: string
+      id:
+        type: integer
+      retryCount:
+        description: Number of retry attempts made
+        type: integer
+      status:
+        $ref: '#/definitions/model.MailLogStatus'
+      subject:
+        type: string
+      to:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  model.MailLogStatus:
+    enum:
+    - delivered
+    - temporary_error
+    - permanent_error
+    type: string
+    x-enum-varnames:
+    - MailLogStatusDelivered
+    - MailLogStatusTemporaryError
+    - MailLogStatusPermanentError
 info:
   contact: {}
   description: This is a sample API for KU-Work
@@ -454,6 +492,38 @@ paths:
       security:
       - BearerAuth: []
       summary: Get an Audit Log (Admin only)
+      tags:
+      - Admin
+  /admin/emaillog:
+    get:
+      description: Retrieves a list logs related to email i.e, sending success failure,
+        to whom.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of all audit log entries
+          schema:
+            items:
+              $ref: '#/definitions/model.MailLog'
+            type: array
+        "403":
+          description: Forbidden
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get log of email (Admin only)
       tags:
       - Admin
   /applications:
@@ -806,8 +876,8 @@ paths:
       - Authentication
   /auth/logout:
     post:
-      description: Invalidates the user's session by deleting their refresh token
-        from the database and clearing the refresh token cookie.
+      description: Invalidates the user's session by revoking both the JWT token (blacklist)
+        and refresh token. Complies with OWASP session termination requirements.
       produces:
       - application/json
       responses:

--- a/backend/handlers/admin.go
+++ b/backend/handlers/admin.go
@@ -49,3 +49,38 @@ func (h *AdminHandlers) FetchAuditLog(ctx *gin.Context) {
 	}
 	ctx.JSON(http.StatusOK, auditLogEntry)
 }
+
+// @Summary Get log of email (Admin only)
+// @Description Retrieves a list logs related to email i.e, sending success failure, to whom.
+// @Tags Admin
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {array} model.MailLog "List of all audit log entries"
+// @Failure 403 {object} object{error=string} "Forbidden"
+// @Failure 500 {object} object{error=string} "Internal Server Error"
+// @Router /admin/emaillog [get]
+func (h *AdminHandlers) FetchEmailLog(ctx *gin.Context) {
+	type FetchEmailLogInput struct {
+		Offset uint `json:"offset" form:"offset"`
+		Limit  uint `json:"limit" form:"limit" binding:"max=64"`
+	}
+	input := FetchEmailLogInput{
+		Limit: 32,
+	}
+	err := ctx.Bind(&input)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	var emailLogs []model.MailLog
+	result := h.DB.Model(&model.MailLog{}).
+		Offset(int(input.Offset)).
+		Limit(int(input.Limit)).
+		Order(clause.OrderByColumn{Column: clause.Column{Name: "created_at"}, Desc: true}).
+		Find(&emailLogs)
+	if result.Error != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": result.Error.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, emailLogs)
+}

--- a/backend/handlers/routes.go
+++ b/backend/handlers/routes.go
@@ -89,5 +89,6 @@ func SetupRoutes(router *gin.Engine, db *gorm.DB, redisClient *redis.Client, ema
 	// Admin Routes
 	admin := protectedRouter.Group("/admin", middlewares.AdminPermissionMiddleware(db))
 	admin.GET("/audits", adminHandlers.FetchAuditLog)
+	admin.GET("/emaillog", adminHandlers.FetchEmailLog)
 	return nil
 }

--- a/backend/model/email.go
+++ b/backend/model/email.go
@@ -11,14 +11,14 @@ const (
 )
 
 type MailLog struct {
-	ID               uint   `gorm:"primary_key"`
-	To               string `gorm:"not null"`
-	Subject          string `gorm:"not null"`
-	Body             string `gorm:"not null"`
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
-	Status           MailLogStatus `gorm:"not null"`
-	ErrorCode        string
-	ErrorDescription string
-	RetryCount       int `gorm:"default:0"` // Number of retry attempts made
+	ID               uint          `gorm:"primary_key" json:"id"`
+	To               string        `gorm:"not null" json:"to"`
+	Subject          string        `gorm:"not null" json:"subject"`
+	Body             string        `gorm:"not null" json:"body"`
+	CreatedAt        time.Time     `json:"createdAt"`
+	UpdatedAt        time.Time     `json:"updatedAt"`
+	Status           MailLogStatus `gorm:"not null" json:"status"`
+	ErrorCode        string        `json:"errorCode,omitempty"`
+	ErrorDescription string        `json:"errorDesc,omitempty"`
+	RetryCount       int           `gorm:"default:0" json:"retryCount"` // Number of retry attempts made
 }


### PR DESCRIPTION
### Description

- Adds an API to fetch email logs for admin so admins can look at it (and possibly email manually)

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have updated the documentation, if applicable.
- [x] My code follows the Coding Guidelines.